### PR TITLE
Fix missing notes rendering

### DIFF
--- a/lib/drum_score_view.dart
+++ b/lib/drum_score_view.dart
@@ -29,9 +29,11 @@ class _DrumScoreViewState extends State<DrumScoreView> {
 
 
   Future<void> _sendScore() async {
-    final jsonString = await rootBundle.loadString('assets/scores/back_in_black_v2.json');
-    final jsCommand = "renderScore(${jsonString.replaceAll("\n", "")});";
-    _controller.runJavaScript(jsCommand);
+    final jsonMap = jsonDecode(
+      await rootBundle.loadString('assets/scores/back_in_black_v2.json'),
+    );
+    final jsCommand = 'renderScore(${jsonEncode(jsonMap)});';
+    await _controller.runJavaScript(jsCommand);
   }
 
   @override


### PR DESCRIPTION
## Summary
- load drum score JSON, then encode before invoking JS
- send sanitized score data to the WebView script to ensure notes render

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888867fd1d883268bf757c487c7739f